### PR TITLE
add unconference and two unconference planning meetings

### DIFF
--- a/calendars/community.yaml
+++ b/calendars/community.yaml
@@ -80,3 +80,19 @@ events:
     begin: 2023-08-31 15:00:00
     timezone: Europe/Helsinki
     duration: { hours: 1 }
+
+  - summary: Planning meeting for the 2023 Unconference
+    description: |
+      A planning meeting for the upcoming unconference. Notes/status at
+      https://hackmd.io/@nordic-rse/unconference-planning.
+    begin: 2023-10-23 15:30:00
+    timezone: Europe/Helsinki
+    duration: { minutes: 30 }
+
+  - summary: Planning meeting for the 2023 Unconference
+    description: |
+      A planning meeting for the upcoming unconference. Notes/status at
+      https://hackmd.io/@nordic-rse/unconference-planning.
+    begin: 2023-10-24 15:00:00
+    timezone: Europe/Helsinki
+    duration: { hours: 1 }

--- a/calendars/conferences.yaml
+++ b/calendars/conferences.yaml
@@ -21,5 +21,18 @@ events:
     begin: 2022-10-19 13:00:00
     duration: { hours: 3 }
 
+  - summary: Unconference 2023
+    description: |
+      Nordic RSE 2023 Unconference. See the event page
+      at https://nordic-rse.org/events/2023-online-unconference/
+      and registration page at https://indico.neic.no/e/nordic-rse-unconference-2023
+    begin: 2022-10-25 13:00:00
+    duration: { hours: 3 }
 
-
+  - summary: Unconference 2023
+    description: |
+      Nordic RSE 2023 Unconference. See the event page
+      at https://nordic-rse.org/events/2023-online-unconference/
+      and registration page at https://indico.neic.no/e/nordic-rse-unconference-2023
+    begin: 2022-10-26 13:00:00
+    duration: { hours: 3 }


### PR DESCRIPTION
The planning meetings are on the Monday and Tuesday just before the event (Wednesday and Thursday).